### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Craftstatic.php
+++ b/src/Craftstatic.php
@@ -35,7 +35,7 @@ class Craftstatic extends Plugin
         parent::init();
         self::$plugin = $this;
 
-        Craft::$app->view->twig->addExtension(new CraftStaticTwigExtension());
+        Craft::$app->view->registerTwigExtension(new CraftStaticTwigExtension());
 
         Event::on(
             Elements::class,


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.